### PR TITLE
Capture SIGTERM only once

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,7 @@ function serverStart() {
     winston.info('Server started!');
   });
 
-  process.on('SIGTERM', () => {
+  process.once('SIGTERM', () => {
     winston.info('Server shutting down. Good bye!');
     process.exit();
   });


### PR DESCRIPTION
If a 2nd SIGTERM arrives, it's probably safe to assume our handler failed to do the right thing, so better let node care about any non-first SIGTERMs.